### PR TITLE
Bump API version from 0.8.0 to 0.8.1

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
     "info" : {
         "title" : "DfE CSC API",
         "description" : "API for the collection of Child Social Care data",
-        "version" : "0.8.0"
+        "version" : "0.8.1"
     },
     "servers" : [
         {


### PR DESCRIPTION
Updating version as failed to do this and has caused confusion